### PR TITLE
Fix fallback when pdflatex is unavailable

### DIFF
--- a/arxivprep
+++ b/arxivprep
@@ -154,7 +154,7 @@ main() {
       -o -iname '*.cls' \
       -o -iname '*.sty' \
       -o -iname '*.pdf' \
-      -o -iname '*.jpeg'\ 
+      -o -iname '*.jpeg'\
       -o -iname '*.jpg' \
       -o -iname '*.png')}
   fi


### PR DESCRIPTION
A trailing space split the find command into two, outputting an error and preventing jpeg, jpg and png files from being included.