### PR TITLE
Use multiline globally for compatibility with Python 3.11+

### DIFF
--- a/striptexcomments
+++ b/striptexcomments
@@ -27,6 +27,7 @@
 # python striptexcomments input.tex -e encoding > output.tex
 #
 import ply.lex, argparse, io
+import re
 
 def strip_comments(source):
     tokens = (
@@ -57,7 +58,7 @@ def strip_comments(source):
 
     # Comments from % at beginning of line to end of line
     def t_BOLPCT(t):
-        r"(?m)^\s*\%"
+        r"^\s*\%"
         # ply uses the re module internally. In the re module ^ is by default
         # interpreted only at the beginning of a string and NOT at beginning of
         # every line. The multi-line flag (?m) changes this behavior to make ^
@@ -187,7 +188,7 @@ def strip_comments(source):
     def t_ANY_error(t):
         t.lexer.skip(1)
 
-    lexer = ply.lex.lex()
+    lexer = ply.lex.lex(reflags=re.VERBOSE | re.MULTILINE)
     lexer.input(source)
     return u"".join([tok.value for tok in lexer])
 

--- a/striptexcomments
+++ b/striptexcomments
@@ -60,10 +60,6 @@ def strip_comments(source):
     # Comments from % at beginning of line to end of line
     def t_BOLPCT(t):
         r"^\s*\%"
-        # ply uses the re module internally. In the re module ^ is by default
-        # interpreted only at the beginning of a string and NOT at beginning of
-        # every line. The multi-line flag (?m) changes this behavior to make ^
-        # match the beginning of every line.
         t.lexer.begin("linecomment")
 
     # Comments from % mid-line to end of line
@@ -189,6 +185,10 @@ def strip_comments(source):
     def t_ANY_error(t):
         t.lexer.skip(1)
 
+    # ply uses the re module internally. In the re module ^ is by default
+    # interpreted only at the beginning of a string and NOT at beginning of
+    # every line. The MULTILINE flag changes this behavior to make ^ match
+    # the beginning of every line.
     lexer = ply.lex.lex(reflags=re.VERBOSE | re.MULTILINE)
     lexer.input(source)
     return u"".join([tok.value for tok in lexer])


### PR DESCRIPTION
Proposed solution in https://github.com/thomasnyman/arxivprep/issues/1.