### PR TITLE
Don't use print for bytes output

### DIFF
--- a/striptexcomments
+++ b/striptexcomments
@@ -27,6 +27,7 @@
 # python striptexcomments input.tex -e encoding > output.tex
 #
 import ply.lex, argparse, io
+import sys
 
 def strip_comments(source):
     tokens = (
@@ -202,7 +203,7 @@ def main():
     with io.open(args.filename, encoding=args.encoding) as f:
         source = f.read()
 
-    print(strip_comments(source).encode(args.encoding))
+    sys.stdout.buffer.write(strip_comments(source).encode(args.encoding))
 
 if __name__ == '__main__':
     main()

--- a/striptexcomments
+++ b/striptexcomments
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2019 Thomas Nyman <thomas.nyman@iki.fi>
 #


### PR DESCRIPTION
Previously, the output tex files would be a pretty-printed version of the bytes output (`b'…'`).